### PR TITLE
update `read.csv()` path and include download instructions to obtain data that is plotted

### DIFF
--- a/code/R/README.md
+++ b/code/R/README.md
@@ -1,0 +1,7 @@
+The R notebook in this directory uses a CSV file of cell measurements from Cellprofiler.
+This CSV file is available on zenodo at https://zenodo.org/record/6999004#.Yv19TvHMLao (DOI: 10.5281/zenodo.6999004).
+It can be downloaded using the following command:
+
+```
+curl -JLO https://zenodo.org/record/6999004/files/measurements_Cells.csv.gz\?download\=1
+```

--- a/code/R/analyzing_chlamydomonas_movement_384_vs_microchambers.ipynb
+++ b/code/R/analyzing_chlamydomonas_movement_384_vs_microchambers.ipynb
@@ -55,12 +55,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 1,
    "id": "6f36bf57",
    "metadata": {},
    "outputs": [],
    "source": [
-    "dat = read.csv('~/Desktop/protist_movement/movement_data/chlamydomonas/microchamber_vs_384_galo_pub_data/measurements_Cells.csv')"
+    "dat = read.csv('measurements_Cells.csv.gz')"
    ]
   },
   {


### PR DESCRIPTION
This PR adds instructions for obtaining the data plotted in the R notebook, including a zenodo url for a project, zenodo doi, and a command to download the file. It also updates the R notebook `read.csv()` command to reflect where the data will be if the `curl` command is run in the R folder.